### PR TITLE
Content update 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=g++
-FLAGS=-std=c++11 -Wall -Wextra
+FLAGS=-std=c++11 -Wall -Wextra -g
 
 LIBS=-lSDL2 -lSDL2_ttf
 #ifdef __MINGW32__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,14 +50,16 @@ int main(int argv, char** args)
     Window win = Window(window, renderer);
 
     PushButton btn1 = PushButton();
-    btn1.setText("Button One");
+    btn1.setText("Long Text Button");
 
     PushButton btn2 = PushButton();
-    btn2.setText("Button Two");
+    btn2.setText("shrt txt btn");
 
     Box box = Box(BoxAxis::Vertical);
     box.addChildView(&btn1);
     box.addChildView(&btn2);
+
+    box.useContentSizeOnAxis = true;
 
     win.setRootView(&box);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,11 +55,11 @@ int main(int argv, char** args)
     PushButton btn2 = PushButton();
     btn2.setText("Button Two");
 
-    Box hbox = Box(BoxAxis::Horizontal);
-    hbox.addChildView(&btn1);
-    hbox.addChildView(&btn2);
+    Box box = Box(BoxAxis::Vertical);
+    box.addChildView(&btn1);
+    box.addChildView(&btn2);
 
-    win.setRootView(&hbox);
+    win.setRootView(&box);
 
     bool quit = false;
     while (!quit)

--- a/src/ui/label.cpp
+++ b/src/ui/label.cpp
@@ -22,6 +22,15 @@
 
 #include "label.h"
 
+Label::Label() {
+    this->inferContentSize = true;
+}
+
+Size *Label::contentSize() {
+    Size* size = new Size(100, 100);
+    return size;
+}
+
 LabelAlignment Label::getVerticalAlignment()
 {
     return this->m_verticalAlignment;

--- a/src/ui/label.cpp
+++ b/src/ui/label.cpp
@@ -26,9 +26,17 @@ Label::Label() {
     this->inferContentSize = true;
 }
 
-Size *Label::contentSize() {
-    Size* size = new Size(100, 100);
-    return size;
+Size *Label::contentSize()
+{
+    if (m_textTexture != NULL) {
+        int textTextureWidth, textTextureHeight;
+        SDL_QueryTexture(m_textTexture, NULL, NULL, &textTextureWidth, &textTextureHeight);
+
+        Size* size = new Size(textTextureWidth, textTextureHeight);
+        return size;
+    }
+
+    return NULL;
 }
 
 LabelAlignment Label::getVerticalAlignment()
@@ -40,7 +48,8 @@ LabelAlignment Label::getHorizontalAlignment()
     return this->m_horizontalAlignment;
 }
 
-void Label::setVerticalAlignment(LabelAlignment alignment) {
+void Label::setVerticalAlignment(LabelAlignment alignment)
+{
     this->m_verticalAlignment = alignment;
 }
 void Label::setHorizontalAlignment(LabelAlignment alignment)

--- a/src/ui/label.h
+++ b/src/ui/label.h
@@ -66,7 +66,7 @@ private:
     std::string m_text = "Label";
     int m_textSize = 16;
 
-    SDL_Texture *m_textTexture;
+    SDL_Texture *m_textTexture = NULL;
 
     Rect m_calculateLabelRect(Size textureSize);
 };

--- a/src/ui/label.h
+++ b/src/ui/label.h
@@ -42,6 +42,10 @@ public:
     LabelAlignment getVerticalAlignment();
     LabelAlignment getHorizontalAlignment();
 
+    Label();
+
+    virtual Size *contentSize();
+
     void setVerticalAlignment(LabelAlignment alignment);
     void setHorizontalAlignment(LabelAlignment alignment);
 

--- a/src/ui/layout/box.cpp
+++ b/src/ui/layout/box.cpp
@@ -80,6 +80,9 @@ void Box::m_updateChildrenFrame()
     for (auto const& child: this->m_childViews)
     {
         Size *inferredSize = child->getInferredSize();
+
+
+
         if (inferredSize != NULL)
         {
             if (this->useContentSizeOnAxis)
@@ -96,8 +99,8 @@ void Box::m_updateChildrenFrame()
                 }
             }
 
-            if (this->getAxis() == BoxAxis::Horizontal) { child->setPosition(Point(this->getFrame().point.x + positionUnits, this->getFrame().point.y)); positionUnits += inferredSize->h; }
-            else { child->setPosition(Point(this->getFrame().point.x, this->getFrame().point.y + positionUnits)); positionUnits += inferredSize->w; }
+            if (this->getAxis() == BoxAxis::Horizontal) { child->setPosition(Point(this->getFrame().point.x + positionUnits, this->getFrame().point.y)); positionUnits += inferredSize->w; }
+            else { child->setPosition(Point(this->getFrame().point.x, this->getFrame().point.y + positionUnits)); positionUnits += inferredSize->h; }
         }
         else {
             if (this->getAxis() == BoxAxis::Horizontal)

--- a/src/ui/layout/box.cpp
+++ b/src/ui/layout/box.cpp
@@ -72,7 +72,7 @@ void Box::m_updateChildrenFrame()
     int freeSpace = boxUnit - inferredSizeTotal;
 
     int unitsPerChild = 0;
-    if (resizeableItems > 0 || freeSpace > 0) {
+    if (resizeableItems > 0 && freeSpace > 0) {
         unitsPerChild = freeSpace / resizeableItems;
     }
     
@@ -82,7 +82,19 @@ void Box::m_updateChildrenFrame()
         Size *inferredSize = child->getInferredSize();
         if (inferredSize != NULL)
         {
-            child->setSize(*inferredSize);
+            if (this->useContentSizeOnAxis)
+            {
+                child->setSize(*inferredSize);
+            }
+            else {
+                if (this->getAxis() == BoxAxis::Horizontal)
+                {
+                    child->setSize(Size(inferredSize->w, this->getFrame().size.h));
+                }
+                else {
+                    child->setSize(Size(this->getFrame().size.w, inferredSize->h));
+                }
+            }
 
             if (this->getAxis() == BoxAxis::Horizontal) { child->setPosition(Point(this->getFrame().point.x + positionUnits, this->getFrame().point.y)); positionUnits += inferredSize->h; }
             else { child->setPosition(Point(this->getFrame().point.x, this->getFrame().point.y + positionUnits)); positionUnits += inferredSize->w; }

--- a/src/ui/layout/box.h
+++ b/src/ui/layout/box.h
@@ -43,6 +43,11 @@ public:
 
     void addChildView(View *child);
 
+    /*
+     * Use the width/height given from view's content size on the box's axis, (e.g. should use the width given from a view with a vertical axis and vice versa).
+     */
+    bool useContentSizeOnAxis = false;
+
     virtual void render(SDL_Renderer *context);
     virtual void processEvents(SDL_Event* event);
     virtual void windowSizeChanged();

--- a/src/ui/pushbutton.cpp
+++ b/src/ui/pushbutton.cpp
@@ -28,4 +28,11 @@ PushButton::PushButton() {
 
     this->allowsClick = true;
     this->setText("Button");
+
+    this->inactiveBackgroundColor = Color(196, 196, 196, 255);
+    this->activeBackgroundColor = Color(0, 122, 255, 255);
+    this->disabledBackgroundColor = Color(150, 150, 150, 255);
+    this->inactiveForegroundColor = Color(0, 0, 0, 255);
+    this->activeForegroundColor = Color(255, 255, 255, 255);
+    this->disabledForegroundColor = Color(0, 0, 0, 255);
 }

--- a/src/ui/view.cpp
+++ b/src/ui/view.cpp
@@ -57,21 +57,11 @@ void View::render(SDL_Renderer *context)
 */
 Rect View::getFrame()
 {
-    Size *inferredContentSize = this->contentSize();
-    if (this->inferContentSize && inferredContentSize != NULL) {
-        return Rect(this->m_position, *inferredContentSize);
-    } else {
-        return Rect(this->m_position, this->m_size);
-    }
+    return Rect(this->m_position, this->m_size);
 }
 
 void View::setSize(Size size)
 {
-    Size *inferredContentSize = this->contentSize();
-    if (this->inferContentSize && inferredContentSize != NULL)
-    {
-        return;
-    }
     this->m_size = size;
 }
 

--- a/src/ui/view.h
+++ b/src/ui/view.h
@@ -56,19 +56,19 @@ public:
     bool allowsKeyboard = false;
 
     /// The background color to use when inactive
-    Color inactiveBackgroundColor = Color(196, 196, 196, 255);
+    Color inactiveBackgroundColor = Color(255, 255, 255, 255);
 
     /// The background color to use when active
-    Color activeBackgroundColor = Color(249, 192, 0, 255);
+    Color activeBackgroundColor = Color(255, 255, 255, 255);
 
     /// The background color to use when disabled
-    Color disabledBackgroundColor = Color(150, 150, 150, 255);
+    Color disabledBackgroundColor = Color(255, 255, 255, 255);
 
     /// The foreground color to use when inactive
     Color inactiveForegroundColor = Color(0, 0, 0, 255);
 
     /// The foreground color to use when active
-    Color activeForegroundColor = Color(255, 255, 255, 255);
+    Color activeForegroundColor = Color(0, 0, 0, 255);
 
     /// The foreground color to use when disabled
     Color disabledForegroundColor = Color(0, 0, 0, 255);


### PR DESCRIPTION
- Size of a view is now handled by a parent therefore making the inferred content size given by a view a suggestion that can be ignored (e.g. a `Box` can now ignore the inferred content size of a view).
- `Label` and `PushButton` (by extension) now provide an inferred content size based on their text content.